### PR TITLE
Link typofix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The entire Vox Product team contributed to and reviewed this code of conduct, bu
 - Mandy Brown
 
 ## Development
-This code of conduct is built using [Jekyll](www.jekyllrb.com). To develop on this locally, you must:
+This code of conduct is built using [Jekyll](http://www.jekyllrb.com). To develop on this locally, you must:
 - `gem install bundler` if you don't already have bundler installed
 - `bundle install`
 - `jekyll serve` to serve files locally


### PR DESCRIPTION
The Jekyll link was broken, at least the way github displayed the README. This fixes it.
