### PR TITLE
Fix canonical tag and add OG tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: Vox Product Code of Conduct
 email: support@voxmedia.com
 description: > # This code of conduct governs the environment of the Vox Product team.
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "http://voxmedia.com" # the base hostname & protocol for your site
+url: "http://code-of-conduct.voxmedia.com" # the base hostname & protocol for your site
 twitter_username: voxproduct
 github_username:  voxmedia
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,7 @@
 
   <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}" />
   <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}" />
-  <meta property="og:description" content="This code of conduct governs the environment of the Vox Product team. We created it not because we anticipate bad behavior, but because we believe that articulating our values and obligations to one another reinforces the already exceptional level of respect among the team and because having a code provides us with clear avenues to correct our culture should it ever stray from that course. We make this code public in the hopes of contributing to the ongoing conversation about inclusion in the tech, design, and media communities and encourage other teams to fork it and make it their own. To our team, we commit to enforce and evolve this code as our team grows." />
+  <meta property="og:description" content="This code of conduct governs the environment of the Vox Product team. We created it not because we anticipate bad behavior, but because we believe that articulating our values and obligations to one another reinforces the already exceptional level of respect among the team and because having a code provides us with clear avenues to correct our culture should it ever stray from that course." />
   <meta property="og:image" content="{{ "/images/header.jpg" | prepend: site.baseurl | prepend: site.url }}" />
   <meta property="og:image:width" content="1500" />
   <meta property="og:image:height" content="670" />

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
-  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+  <meta name="description" content="This code of conduct governs the environment of the Vox Product team.">
+
+  <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}" />
+  <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}" />
+  <meta property="og:description" content="This code of conduct governs the environment of the Vox Product team. We created it not because we anticipate bad behavior, but because we believe that articulating our values and obligations to one another reinforces the already exceptional level of respect among the team and because having a code provides us with clear avenues to correct our culture should it ever stray from that course. We make this code public in the hopes of contributing to the ongoing conversation about inclusion in the tech, design, and media communities and encourage other teams to fork it and make it their own. To our team, we commit to enforce and evolve this code as our team grows." />
+  <meta property="og:image" content="{{ "/images/header.jpg" | prepend: site.baseurl | prepend: site.url }}" />
+  <meta property="og:image:width" content="1500" />
+  <meta property="og:image:height" content="670" />
+  <meta property="og:type" content="website" />
 
   <link rel="stylesheet" href="{{ "css/all.css" | prepend: site.baseurl }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">


### PR DESCRIPTION
- Changes the site URL in the config file so the `rel=canonical` tag points to the right URL (which currently prevents the COC from being shared on Facebook, since it makes the share point to voxmedia.com)
- Adds a few OpenGraph tag so sharing the COC on Facebook looks nice.
